### PR TITLE
Fixed env setting in pre-commit hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DJANGO_SETTINGS_MODULE=mysterio.settings.local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,9 @@ repos:
     hooks:
     -    id: pylint
          language: system
-         entry: bash -c 'exec env DJANGO_SETTINGS_MODULE=mysterio.settings.local'
+         entry: dotenv run pylint
          verbose: true
+         args: ["--disable=W0511"]
 -   repo: local
     hooks:
     -    id: test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
          entry: dotenv run pylint
          verbose: true
          args: ["--disable=W0511"]
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.12.0
+    hooks:
+    -    id: eslint
+         args: ["--max-warnings=0"]
 -   repo: local
     hooks:
     -    id: test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
     -    id: test
          name: test
          language: system
-         entry: ./manage.py test
+         entry: python manage.py test
          pass_filenames: false
          verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v7.12.0
     hooks:
     -    id: eslint
+         verbose: true
          args: ["--max-warnings=0"]
 -   repo: local
     hooks:

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -3,5 +3,10 @@
     "parser": "babel-eslint",
     "rules": {
         "eol-last": ["error", "always"]
+    },
+    "settings": {
+      "react": {
+        "version": "latest"
+      }
     }
 }

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "extends": "react-app",
     "parser": "babel-eslint",
     "rules": {
         "eol-last": ["error", "always"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,9 +18,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-python-dotenv==0.14.0
+python-dotenv[cli]==0.14.0
 pylint==2.6.0
 pylint-django==2.3.0
 pre-commit==2.7.1


### PR DESCRIPTION
- Used dotnev cli to run pre-hook pylint with env variables
- Updated .env.example to contain DJANGO_SETTINGS_MODULE env variable required by pylint-django
- Disabled "fixme" warning in pre-hook pylint
- Added eslint in pre-commit hook

**BREAKING CHANGE:**
After this change, for local development, create .env file in project root with contents of .env.example. This .env file can be used to put additional env variables as required for local development.